### PR TITLE
Deploy documentation to GitHub Pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+Changelog
+---------
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+Checklist
+---------
+
+* [ ] Test
+* [ ] Self-review
+* [ ] Documentation

--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -1,4 +1,18 @@
-name: 'Deploy Documentation to GitHub Pages'
+# Copyright 2023 Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: "Deploy Documentation to GitHub Pages"
 
 on:
   push:

--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -1,0 +1,34 @@
+name: 'Deploy Documentation to GitHub Pages'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  doc-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ruby as asciidoctor Prerequisite
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install asciidoctor
+        uses: reitzig/actions-asciidoctor@v2.0.0
+        with:
+          version: 2.0.10
+      - name: Build Documentation Using Native Tool - asciidoctor
+        run: |
+          cd docs
+          asciidoctor all_in_one.adoc
+          mv all_in_one.html index.html
+      - name: Deploy Documentation to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          user_name: QubitPi
+          user_email: jack20191124@proton.me


### PR DESCRIPTION
Changelog
---------

### Added

- Each PR & master branch commit deploys the documentation to [GitHub Pages](https://qubitpi.github.io/spock-doc/)
- Added PR template

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
